### PR TITLE
Fix to CanGRD download link not displaying when trend values selected.

### DIFF
--- a/src/components/URLBox.vue
+++ b/src/components/URLBox.vue
@@ -30,7 +30,7 @@
       <div
         id="wfs3-download-links-list"
         class="mrgn-tp-md"
-        v-show="wfs3CommonUrl !== null && numRecords !== null">
+        v-show="wfs3CommonUrl !== null && numRecords !== null && hasErrors === false">
 
         <p>
           <strong
@@ -54,7 +54,7 @@
       <div
         id="wcs-download-links-list"
         class="mrgn-tp-md"
-        v-show="wcsCommonUrl !== null">
+        v-show="wcsCommonUrl !== null && hasErrors === false">
 
         <div id="wcs-link-list" class="list-group" aria-live="polite">
           <a
@@ -90,7 +90,7 @@ export default {
     bandRangeFormat: {
       type: Function,
       default: function (bandStart, bandEnd) {
-        if (bandStart === null || bandEnd === null || bandStart === 'Invalid date' || bandEnd === 'Invalid date') {
+        if (bandStart === null || bandEnd === null || bandStart === 'Invalid date' || bandEnd === 'Invalid date' || typeof bandStart === 'undefined' || typeof bandEnd === 'undefined') {
           return null
         } else if (bandStart === bandEnd) { // single date
           return 'B' + bandStart
@@ -221,7 +221,9 @@ export default {
         return this.$_i(this.$gettext('Download: {date}'), {'date': bandChunk.start})
       } else if (rangeSubset !== null) {
         return this.$_i(this.$gettext('Download: {startNum} - {endNum}'), {'startNum': bandChunk.start, 'endNum': bandChunk.end})
-      } else {
+      } else if (bandChunk.hasOwnProperty('specialTitle')) {
+        return this.$gettext('Download:') + ' ' + bandChunk.specialTitle
+      } else { // default
         return this.$gettext('Download:') + ' ' + title
       }
     },

--- a/src/components/mixins/wcs.js
+++ b/src/components/mixins/wcs.js
@@ -40,9 +40,7 @@ export const wcs = {
       var chunkEndMoment = this.$moment.utc(this.bandStartMoment)
       var chunkDuration
 
-      if (this.wcs_id_dataset === 'CANGRD' && this.wcs_id_cangrdType === 'TREND') { // CanGRD trends don't have date ranges
-        return []
-      } else if (this.hasCommonBandErrors) { // range 0 or errors
+      if (this.hasCommonBandErrors) { // range 0 or errors
         return []
       } else if (this.usesBands) {
         var chunkedBands = []
@@ -74,6 +72,24 @@ export const wcs = {
 
         return chunkedBands
       } else { // no bands (empty)
+        if (this.wcs_id_dataset === 'CANGRD' && this.wcs_id_cangrdType === 'TREND') {
+          // CanGRD trends special title
+          return [{
+            'start': null,
+            'end': null,
+            'duration': 0,
+            'specialTitle': this.variableTypeOptions[this.wcs_id_cangrdType]
+          }]
+        } else if (this.rangeType === 'year20' && (this.wcs_id_dataset === 'DCS' || this.wcs_id_dataset === 'CMIP5')) {
+          // DCS or CMIP5 20-year average special title
+          return [{
+            'start': null,
+            'end': null,
+            'duration': 0,
+            'specialTitle': this.rangeTypeOptions[this.rangeType]
+          }]
+        }
+
         return [{
           'start': null,
           'end': null,
@@ -136,7 +152,7 @@ export const wcs = {
     },
     bandRangeFormat: function (bandStart, bandEnd) {
       // Check for null and append "B"
-      if (bandStart === null || bandEnd === null || bandStart === 'Invalid date' || bandEnd === 'Invalid date') {
+      if (bandStart === null || bandEnd === null || bandStart === 'Invalid date' || bandEnd === 'Invalid date' || typeof bandStart === 'undefined' || typeof bandEnd === 'undefined') {
         return null
       } else if (bandStart === bandEnd) { // single date
         return 'B' + bandStart


### PR DESCRIPTION
- Added special text instead of generic dataset name for DCS, CMIP5 and CanGRD download links with no bands.