### PR TITLE
Retires for xhr requests ticket: #275

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pnpm-debug.log*
 *.pot
 /cypress.env.json
 /debug.log
-/cypress
+/cypress/**
+!cypress/tsconfig.json
 /tests/e2e/screenshots
 /tests/e2e/videos

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+      "types": ["cypress", "cypress-wait-until"]
+    }
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.16.7.tgz",
       "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.16.7"
       },
@@ -317,7 +316,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmmirror.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
       "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
       },
@@ -435,7 +433,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
       "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -482,7 +479,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmmirror.com/@babel/highlight/-/highlight-7.17.9.tgz",
       "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
@@ -1645,7 +1641,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.17.9.tgz",
       "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1692,7 +1687,6 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -1757,6 +1751,71 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/@emotion/babel-utils": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
+      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
+      "peer": true,
+      "dependencies": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/serialize": "^0.9.1",
+        "convert-source-map": "^1.5.1",
+        "find-root": "^1.1.0",
+        "source-map": "^0.7.2"
+      }
+    },
+    "node_modules/@emotion/babel-utils/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==",
+      "peer": true
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==",
+      "peer": true
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
+      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+      "peer": true,
+      "dependencies": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/unitless": "^0.6.7",
+        "@emotion/utils": "^0.8.2"
+      }
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==",
+      "peer": true
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==",
+      "peer": true
+    },
+    "node_modules/@emotion/utils": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
+      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
+      "peer": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -2146,6 +2205,12 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "peer": true
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -2175,6 +2240,15 @@
       "resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.11.tgz",
+      "integrity": "sha512-VwAYom2pfIAf/pLj1VR5aLltd4tOtHyvfaJlNYCoejzP2nu52PrMi1ehsLRMUS+bgafmIIKBV1cMfKeS+uJ0Vg==",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -2207,8 +2281,7 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/parse5": {
       "version": "5.0.3",
@@ -3333,6 +3406,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "peer": true
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmmirror.com/accepts/-/accepts-1.3.8.tgz",
@@ -3604,7 +3683,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -3848,6 +3926,53 @@
         "object.assign": "^4.1.0"
       }
     },
+    "node_modules/babel-plugin-emotion": {
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
+      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/babel-utils": "^0.6.4",
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "find-root": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.5.7",
+        "touch": "^2.0.1"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
       "resolved": "https://registry.npmmirror.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
@@ -3886,6 +4011,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "peer": true
     },
     "node_modules/babel-runtime": {
       "version": "6.26.0",
@@ -4165,7 +4296,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4238,7 +4368,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4627,7 +4756,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -4635,8 +4763,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/colord": {
       "version": "2.9.2",
@@ -4807,7 +4934,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -4905,6 +5031,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/create-emotion": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
+      "peer": true,
+      "dependencies": {
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "@emotion/unitless": "^0.6.2",
+        "csstype": "^2.5.2",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10"
       }
     },
     "node_modules/cross-spawn": {
@@ -5213,6 +5354,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/csstype": {
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+      "peer": true
     },
     "node_modules/cypress": {
       "version": "8.3.0",
@@ -6014,6 +6161,22 @@
         "node": ">= 4"
       }
     },
+    "node_modules/emotion": {
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.6.tgz",
+      "integrity": "sha512-95/EiWkADklxyy1y1qlJeX5Cepa7WfpJBJSBgbLkDCBzOnP4maluvz52xcV5UaObBTfVnEBq77Go6/bgF7+xaA==",
+      "peer": true,
+      "dependencies": {
+        "babel-plugin-emotion": "^9.2.6",
+        "create-emotion": "^9.2.6"
+      }
+    },
+    "node_modules/emotion-utils": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/emotion-utils/-/emotion-utils-9.1.0.tgz",
+      "integrity": "sha512-Zdy9TiZzMDRsCufivL/ZhQ0JdfGGSOc20opRjaBOemF5h2kYI/MD/bLcXfAZgzYVL12WNQegZIme6l+N/JFE4Q==",
+      "peer": true
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -6086,7 +6249,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -7065,6 +7227,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "peer": true
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmmirror.com/find-up/-/find-up-4.1.0.tgz",
@@ -7492,7 +7660,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -7830,7 +7997,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -7906,8 +8072,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -8391,8 +8556,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -8434,8 +8598,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmmirror.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -8629,8 +8792,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/listr2": {
       "version": "3.14.0",
@@ -9333,8 +9495,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -9352,7 +9513,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9412,6 +9572,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nano-assign": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-assign/-/nano-assign-1.0.1.tgz",
+      "integrity": "sha512-1K8ncUoAYFPYcCZqrB+K2XQaFCmA35rryJCtPkGrG3zYkwm+iIUZRIHyaAfuy6zxaK9siPdjeJq7+Inijm6xhw==",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.2",
@@ -9510,6 +9676,21 @@
       "resolved": "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.3.tgz",
       "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
       "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -9908,7 +10089,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -9920,7 +10100,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -10011,7 +10190,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11101,8 +11279,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -11267,7 +11444,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11974,11 +12150,25 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "peer": true
+    },
+    "node_modules/stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "peer": true,
+      "peerDependencies": {
+        "stylis": "^3.5.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -12267,7 +12457,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12307,6 +12496,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
+      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
+      "peer": true,
+      "dependencies": {
+        "nopt": "~1.0.10"
+      },
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tough-cookie": {
@@ -12687,6 +12891,19 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
       "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+    },
+    "node_modules/vue-emotion": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/vue-emotion/-/vue-emotion-0.4.2.tgz",
+      "integrity": "sha512-Ve2ZHmuTyu1JTVhrS9/5fHoO0EpWgNtlqKrzWWX0oIzzowl3OAmn8FV73SBawCHGdTccnKhkSNTT5kSxha1l/Q==",
+      "peer": true,
+      "dependencies": {
+        "emotion-utils": "^9.1.0",
+        "nano-assign": "^1.0.0"
+      },
+      "peerDependencies": {
+        "emotion": "^9.0.0"
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "8.3.0",
@@ -13788,7 +14005,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -13934,7 +14150,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.16.7.tgz",
       "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.16.7"
       }
@@ -14112,7 +14327,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmmirror.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
       "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       }
@@ -14202,8 +14416,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.16.7",
       "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-      "dev": true
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
     },
     "@babel/helper-validator-option": {
       "version": "7.16.7",
@@ -14238,7 +14451,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmmirror.com/@babel/highlight/-/highlight-7.17.9.tgz",
       "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
@@ -15014,7 +15226,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.17.9.tgz",
       "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -15052,7 +15263,6 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -15112,6 +15322,70 @@
           }
         }
       }
+    },
+    "@emotion/babel-utils": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
+      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
+      "peer": true,
+      "requires": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/serialize": "^0.9.1",
+        "convert-source-map": "^1.5.1",
+        "find-root": "^1.1.0",
+        "source-map": "^0.7.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "peer": true
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==",
+      "peer": true
+    },
+    "@emotion/memoize": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==",
+      "peer": true
+    },
+    "@emotion/serialize": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
+      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+      "peer": true,
+      "requires": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/unitless": "^0.6.7",
+        "@emotion/utils": "^0.8.2"
+      }
+    },
+    "@emotion/stylis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==",
+      "peer": true
+    },
+    "@emotion/unitless": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==",
+      "peer": true
+    },
+    "@emotion/utils": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
+      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
+      "peer": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -15443,6 +15717,12 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "peer": true
+    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -15472,6 +15752,15 @@
       "resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "@types/leaflet": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.11.tgz",
+      "integrity": "sha512-VwAYom2pfIAf/pLj1VR5aLltd4tOtHyvfaJlNYCoejzP2nu52PrMi1ehsLRMUS+bgafmIIKBV1cMfKeS+uJ0Vg==",
+      "peer": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -15504,8 +15793,7 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/parse5": {
       "version": "5.0.3",
@@ -16467,6 +16755,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "peer": true
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmmirror.com/accepts/-/accepts-1.3.8.tgz",
@@ -16660,7 +16954,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -16863,6 +17156,52 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
+      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/babel-utils": "^0.6.4",
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "find-root": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.5.7",
+        "touch": "^2.0.1"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "peer": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        }
+      }
+    },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
       "resolved": "https://registry.npmmirror.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
@@ -16892,6 +17231,12 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.1"
       }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "peer": true
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -17139,8 +17484,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camel-case": {
       "version": "4.1.2",
@@ -17201,7 +17545,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmmirror.com/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -17508,7 +17851,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -17516,8 +17858,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "colord": {
       "version": "2.9.2",
@@ -17662,7 +18003,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -17746,6 +18086,21 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "create-emotion": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
+      "peer": true,
+      "requires": {
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "@emotion/unitless": "^0.6.2",
+        "csstype": "^2.5.2",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10"
       }
     },
     "cross-spawn": {
@@ -17975,6 +18330,12 @@
       "requires": {
         "css-tree": "^1.1.2"
       }
+    },
+    "csstype": {
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+      "peer": true
     },
     "cypress": {
       "version": "8.3.0",
@@ -18615,6 +18976,22 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
+    "emotion": {
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.6.tgz",
+      "integrity": "sha512-95/EiWkADklxyy1y1qlJeX5Cepa7WfpJBJSBgbLkDCBzOnP4maluvz52xcV5UaObBTfVnEBq77Go6/bgF7+xaA==",
+      "peer": true,
+      "requires": {
+        "babel-plugin-emotion": "^9.2.6",
+        "create-emotion": "^9.2.6"
+      }
+    },
+    "emotion-utils": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/emotion-utils/-/emotion-utils-9.1.0.tgz",
+      "integrity": "sha512-Zdy9TiZzMDRsCufivL/ZhQ0JdfGGSOc20opRjaBOemF5h2kYI/MD/bLcXfAZgzYVL12WNQegZIme6l+N/JFE4Q==",
+      "peer": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -18677,7 +19054,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmmirror.com/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -19461,6 +19837,12 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "peer": true
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmmirror.com/find-up/-/find-up-4.1.0.tgz",
@@ -19795,8 +20177,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -20063,7 +20444,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -20121,8 +20501,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmmirror.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -20484,8 +20863,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -20518,8 +20896,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmmirror.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.4.0",
@@ -20684,8 +21061,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmmirror.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "listr2": {
       "version": "3.14.0",
@@ -21256,8 +21632,7 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.6",
@@ -21272,7 +21647,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmmirror.com/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.6"
       }
@@ -21320,6 +21694,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nano-assign": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-assign/-/nano-assign-1.0.1.tgz",
+      "integrity": "sha512-1K8ncUoAYFPYcCZqrB+K2XQaFCmA35rryJCtPkGrG3zYkwm+iIUZRIHyaAfuy6zxaK9siPdjeJq7+Inijm6xhw==",
+      "peer": true
     },
     "nanoid": {
       "version": "3.3.2",
@@ -21392,6 +21772,15 @@
       "resolved": "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.3.tgz",
       "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
       "dev": true
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "peer": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -21707,7 +22096,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -21716,7 +22104,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -21793,8 +22180,7 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pend": {
       "version": "1.2.0",
@@ -22610,8 +22996,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -22746,8 +23131,7 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "restore-cursor": {
       "version": "3.1.0",
@@ -23343,11 +23727,23 @@
         "postcss-selector-parser": "^6.0.4"
       }
     },
+    "stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "peer": true
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "peer": true,
+      "requires": {}
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -23574,8 +23970,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -23604,6 +23999,15 @@
       "resolved": "https://registry.npmmirror.com/totalist/-/totalist-1.1.0.tgz",
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
+    },
+    "touch": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
+      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
+      "peer": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -23914,6 +24318,16 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
           "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
+      }
+    },
+    "vue-emotion": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/vue-emotion/-/vue-emotion-0.4.2.tgz",
+      "integrity": "sha512-Ve2ZHmuTyu1JTVhrS9/5fHoO0EpWgNtlqKrzWWX0oIzzowl3OAmn8FV73SBawCHGdTccnKhkSNTT5kSxha1l/Q==",
+      "peer": true,
+      "requires": {
+        "emotion-utils": "^9.1.0",
+        "nano-assign": "^1.0.0"
       }
     },
     "vue-eslint-parser": {
@@ -24779,8 +25193,7 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmmirror.com/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "eslint-plugin-vue": "^8.0.3",
     "html-webpack-plugin": "^4.5.2",
     "po-csv": "^1.0.2",
-    "vue-template-compiler": "^2.6.14"
+    "vue-template-compiler": "^2.6.14",
+    "cypress-wait-until": "^1.7.2"
   },
   "browserslist": [
     "> 1%",

--- a/tests/e2e/specs/ahccd.js
+++ b/tests/e2e/specs/ahccd.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for AHCCD data with various form options', () => {
   it('Check AHCCD stations and download trend values as CSV', () => {
     cy.intercept('GET', /.*\/collections\/ahccd-stations\/items\?.*f=json.*/).as('stationData')
@@ -8,7 +11,7 @@ describe('E2E test for AHCCD data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -20,6 +23,12 @@ describe('E2E test for AHCCD data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(1300)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
 
     // Stations are loaded on the map as clusters
@@ -37,11 +46,17 @@ describe('E2E test for AHCCD data with various form options', () => {
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/ahccd-trends\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(87000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
@@ -83,11 +98,17 @@ describe('E2E test for AHCCD data with various form options', () => {
     cy.intercept('GET', /.*\/collections\/ahccd-annual\/items\?.*province__province=BC.*resulttype=hits.*f=json.*/).as('countProvinceAnnual')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
-    cy.wait('@countProvinceAnnual', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countProvinceAnnual').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(numberMatched) // 20888
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
 
     // visit download link (replace with limit 1)
@@ -127,11 +148,17 @@ describe('E2E test for AHCCD data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/ahccd-seasonal\/items.*/).as('countData')
     cy.get('#retrieve-download-links').click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.equal(1392)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
@@ -178,11 +205,17 @@ describe('E2E test for AHCCD data with various form options', () => {
     const numberMatched = 9200
     cy.intercept('GET', /.*\/collections\/ahccd-monthly\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(numberMatched)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 

--- a/tests/e2e/specs/climate-daily.js
+++ b/tests/e2e/specs/climate-daily.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for climate daily data with various form options', () => {
   it('Check daily climate stations and download data as CSV', () => {
     // station data and daterange
@@ -10,7 +13,7 @@ describe('E2E test for climate daily data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -22,14 +25,28 @@ describe('E2E test for climate daily data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(8400)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
-    cy.wait('@dateRangeData', {timeout: 30000}).then((xhr) => {
+
+    cy.waitUntil(() => cy.wait('@dateRangeData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberReturned).to.be.equal(1)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
 
     // Stations are loaded on the map as clusters
     cy.checkMarkerClusters(10)
@@ -51,12 +68,19 @@ describe('E2E test for climate daily data with various form options', () => {
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/climate-daily\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(600000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -97,12 +121,19 @@ describe('E2E test for climate daily data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-daily\/items\?.*PROVINCE_CODE=BC.*resulttype=hits.*f=json.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(12331000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -143,12 +174,19 @@ describe('E2E test for climate daily data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-daily\/items.*/).as('countData')
     cy.get('#retrieve-download-links').click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(2900)
+    }),  {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -190,12 +228,19 @@ describe('E2E test for climate daily data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-daily\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData', {timeout: 30000}).then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(120000)
+    }),  {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)

--- a/tests/e2e/specs/climate-daily.js
+++ b/tests/e2e/specs/climate-daily.js
@@ -228,7 +228,7 @@ describe('E2E test for climate daily data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-daily\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.waitUntil(() => cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')

--- a/tests/e2e/specs/climate-hourly.js
+++ b/tests/e2e/specs/climate-hourly.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for climate hourly data with various form options', () => {
   it('Check hourly climate stations and download data as CSV', () => {
     // station data and daterange
@@ -10,7 +13,8 @@ describe('E2E test for climate hourly data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 60000}).then((xhr) => {
+
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -22,15 +26,32 @@ describe('E2E test for climate hourly data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(1090)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check 
+
     })
-    cy.wait('@dateRangeData', {timeout: 30000}).then((xhr) => {
+
+
+    cy.waitUntil(() => cy.wait('@dateRangeData').then((xhr) => {
       console.log(xhr)
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberReturned).to.be.equal(1)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check 
+
     })
+
 
     // Stations are loaded on the map as clusters
     cy.checkMarkerClusters(15)
@@ -51,14 +72,22 @@ describe('E2E test for climate hourly data with various form options', () => {
 
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/climate-hourly\/items.*/).as('countData')
-    const numMatched = 34560000
+    const numMatched = 3060000
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 60000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(numMatched)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check 
+
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -100,13 +129,24 @@ describe('E2E test for climate hourly data with various form options', () => {
     // retrieve download links
     const numMatched = 58800
     cy.intercept('GET', /.*\/collections\/climate-hourly\/items\?.*PROVINCE_CODE=BC.*resulttype=hits.*f=json.*/).as('countData')
+
+    
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 60000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(numMatched)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check 
+
     })
+
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -151,12 +191,21 @@ describe('E2E test for climate hourly data with various form options', () => {
     cy.intercept('GET', /.*\/collections\/climate-hourly\/items.*/).as('countData')
     cy.get('#retrieve-download-links').click()
     const numMatched = 70
-    cy.wait('@countData', {timeout: 60000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(numMatched)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check 
+
     })
+      
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -199,11 +248,18 @@ describe('E2E test for climate hourly data with various form options', () => {
     cy.intercept('GET', /.*\/collections\/climate-hourly\/items.*/).as('countData')
     const numMatched = 730
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 60000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(numMatched)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check 
+
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 

--- a/tests/e2e/specs/climate-monthly.js
+++ b/tests/e2e/specs/climate-monthly.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for climate monthly data with various form options', () => {
   it('Check climate monthly stations and download data as CSV', () => {
     // station data and daterange
@@ -10,7 +13,7 @@ describe('E2E test for climate monthly data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -22,14 +25,28 @@ describe('E2E test for climate monthly data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(8200)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
-    cy.wait('@dateRangeData', {timeout: 20000}).then((xhr) => {
+
+    cy.waitUntil(() => cy.wait('@dateRangeData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberReturned).to.be.equal(1)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
 
     // Stations are loaded on the map as clusters
     cy.checkMarkerClusters(15)
@@ -40,12 +57,19 @@ describe('E2E test for climate monthly data with various form options', () => {
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/climate-monthly\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(1835000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -86,12 +110,19 @@ describe('E2E test for climate monthly data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-monthly\/items\?.*PROVINCE_CODE=BC.*resulttype=hits.*f=json.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(375000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -132,12 +163,19 @@ describe('E2E test for climate monthly data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-monthly\/items.*/).as('countData')
     cy.get('#retrieve-download-links').click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.equal(237)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -179,12 +217,19 @@ describe('E2E test for climate monthly data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-monthly\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(3900)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)

--- a/tests/e2e/specs/climate-normals.js
+++ b/tests/e2e/specs/climate-normals.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for climate normals data with various form options', () => {
   it('Check climate normals stations and download data as CSV', () => {
     cy.intercept('GET', /.*\/collections\/climate-stations\/items\?.*f=json.*HAS_NORMALS_DATA=Y.*/).as('stationData')
@@ -8,7 +11,7 @@ describe('E2E test for climate normals data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -20,7 +23,14 @@ describe('E2E test for climate normals data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(720)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
 
     // Stations are loaded on the map as clusters
     cy.checkMarkerClusters(6)
@@ -35,12 +45,19 @@ describe('E2E test for climate normals data with various form options', () => {
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/climate-normals\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(49000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -76,12 +93,19 @@ describe('E2E test for climate normals data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-normals\/items\?.*PROVINCE_CODE=BC.*resulttype=hits.*f=json.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(131000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -118,12 +142,19 @@ describe('E2E test for climate normals data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-normals\/items.*/).as('countData')
     cy.get('#retrieve-download-links').click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.equal(3764)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -161,12 +192,19 @@ describe('E2E test for climate normals data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/climate-normals\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 20000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(9800)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)

--- a/tests/e2e/specs/home.js
+++ b/tests/e2e/specs/home.js
@@ -1,16 +1,25 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for home page', () => {
   it('Visits the app home page and gets expected response', () => {
     // XHR to get latest GitHub release details on page load
     cy.intercept('GET', /https:\/\/api\.github\.com\/repos\/ECCC-CCCS\/climate-data-extraction-tool\/releases\/latest/).as('apiGithubReleaseLatest')
     cy.visit('/') // App home page
-    cy.wait('@apiGithubReleaseLatest').then((xhr) => {
+    cy.waitUntil(() => cy.wait('@apiGithubReleaseLatest').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.statusCode).to.equal(200)
       expect(xhr.response.body).to.have.property('url')
       expect(xhr.response.body.url).to.match(/^https:\/\/api\.github\.com\/repos\/ECCC-CCCS\/climate-data-extraction-tool\/releases\/\d+$/)
       expect(xhr.response.body.tag_name).to.match(/^\d{1,2}\.\d{1,2}\.\d{1,2}$/)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
 
     // Title

--- a/tests/e2e/specs/hydrometric.js
+++ b/tests/e2e/specs/hydrometric.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for hydrometric data with various form options', () => {
   it('Check hydrometric stations and download daily mean data as CSV', () => {
     // station data
@@ -10,7 +13,7 @@ describe('E2E test for hydrometric data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -22,13 +25,19 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(minNumStations)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
 
     // discontinued stations
     cy.intercept('GET', /.*\/collections\/hydrometric-stations\/items\?f=json&limit=10000&properties=PROV_TERR_STATE_LOC,STATION_NAME,STATION_NUMBER,STATUS_EN$/).as('entireStationData')
     cy.get('#toggle-discontinued-stations').click()
     const minNumStationsDiscontinued = 7910
-    cy.wait('@entireStationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@entireStationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -40,6 +49,12 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.be.greaterThan(minNumStationsDiscontinued)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.get('table#station-select-table').scrollIntoView().wait(250).find('tr.selectableStation').should(($tr) => {
       expect($tr.length).to.be.greaterThan(minNumStationsDiscontinued)
@@ -66,11 +81,17 @@ describe('E2E test for hydrometric data with various form options', () => {
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/hydrometric-daily-mean\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(62976000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
@@ -115,11 +136,17 @@ describe('E2E test for hydrometric data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/hydrometric-monthly-mean\/items\?.*PROV_TERR_STATE_LOC=BC.*resulttype=hits.*f=json.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(430570)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
@@ -164,11 +191,17 @@ describe('E2E test for hydrometric data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/hydrometric-annual-peaks\/items.*/).as('countData')
     cy.get('#retrieve-download-links').click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.equal(36)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
@@ -214,11 +247,17 @@ describe('E2E test for hydrometric data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/hydrometric-annual-statistics\/items.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(500)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 

--- a/tests/e2e/specs/hydrometric.js
+++ b/tests/e2e/specs/hydrometric.js
@@ -27,7 +27,7 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body.features.length).to.be.greaterThan(minNumStations)
     }), {
       errorMsg: 'Timeout reached', // overrides the default error message
-      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
       interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
       verbose: true, // log the progress, default to false
       customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
@@ -51,7 +51,7 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body.features.length).to.be.greaterThan(minNumStationsDiscontinued)
     }), {
       errorMsg: 'Timeout reached', // overrides the default error message
-      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
       interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
       verbose: true, // log the progress, default to false
       customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
@@ -88,7 +88,7 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body.numberMatched).to.be.greaterThan(62976000)
     }), {
       errorMsg: 'Timeout reached', // overrides the default error message
-      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
       interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
       verbose: true, // log the progress, default to false
       customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
@@ -143,7 +143,7 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body.numberMatched).to.be.greaterThan(430570)
     }), {
       errorMsg: 'Timeout reached', // overrides the default error message
-      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
       interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
       verbose: true, // log the progress, default to false
       customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
@@ -198,7 +198,7 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body.numberMatched).to.equal(36)
     }), {
       errorMsg: 'Timeout reached', // overrides the default error message
-      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
       interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
       verbose: true, // log the progress, default to false
       customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
@@ -254,7 +254,7 @@ describe('E2E test for hydrometric data with various form options', () => {
       expect(xhr.response.body.numberMatched).to.be.greaterThan(500)
     }), {
       errorMsg: 'Timeout reached', // overrides the default error message
-      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6000 ms
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
       interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
       verbose: true, // log the progress, default to false
       customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check

--- a/tests/e2e/specs/ltce.js
+++ b/tests/e2e/specs/ltce.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for LTCE data with various form options', () => {
   it('Check LTCE stations and download temperature data as CSV', () => {
     // station data
@@ -9,7 +12,7 @@ describe('E2E test for LTCE data with various form options', () => {
     // open map filters box
     cy.get('#map-filters-header').scrollIntoView().wait(250).click()
 
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       try {
@@ -20,8 +23,15 @@ describe('E2E test for LTCE data with various form options', () => {
       }
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
-      expect(xhr.response.body.features.length).to.equal(5812)
+      expect(xhr.response.body.features.length).to.equal(5837)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
 
     // Stations are loaded on the map as clusters
     cy.checkMarkerClusters(10)
@@ -40,12 +50,19 @@ describe('E2E test for LTCE data with various form options', () => {
     // retrieve download list
     cy.intercept('GET', /.*\/collections\/ltce-temperature\/items.*resulttype=hits.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(270000)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -90,12 +107,19 @@ describe('E2E test for LTCE data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/ltce-temperature\/items\?.*LOCAL_MONTH=03.*PROVINCE_CODE=BC.*resulttype=hits.*f=json.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.greaterThan(2898)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -119,13 +143,20 @@ describe('E2E test for LTCE data with various form options', () => {
     // value type
     cy.intercept('GET', /.*\/collections\/ltce-stations\/items\?.*f=json.*ELEMENT_NAME_E=PRECIPITATION.*/).as('stationData')
     cy.selectVar('select#var-sel-climate-element--record-type', 'Precipitation - Daily extremes of record', 'ltce-precipitation')
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.equal(2898)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.get('#map-loading-screen').should('be.hidden')
 
     // Select stations by table
@@ -148,12 +179,19 @@ describe('E2E test for LTCE data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/ltce-precipitation\/items.*resulttype=hits.*/).as('countData')
     cy.get('#retrieve-download-links').click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.equal(3)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)
@@ -177,13 +215,20 @@ describe('E2E test for LTCE data with various form options', () => {
     // value type
     cy.intercept('GET', /.*\/collections\/ltce-stations\/items\?.*f=json.*ELEMENT_NAME_E=SNOWFALL.*/).as('stationData')
     cy.selectVar('select#var-sel-climate-element--record-type', 'Snowfall - Daily extremes of record', 'ltce-snowfall')
-    cy.wait('@stationData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@stationData').then((xhr) => {
       expect(xhr.response.headers).to.have.property('access-control-allow-headers')
       expect(xhr.response.headers).to.have.property('access-control-allow-origin')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.features.length).to.equal(2290)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.get('#map-loading-screen').should('be.hidden')
 
     // Zoom in to map
@@ -205,12 +250,19 @@ describe('E2E test for LTCE data with various form options', () => {
     // retrieve download links
     cy.intercept('GET', /.*\/collections\/ltce-snowfall\/items.*resulttype=hits.*/).as('countData')
     cy.get('#retrieve-download-links').scrollIntoView().wait(250).click()
-    cy.wait('@countData', {timeout: 30000}).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@countData').then((xhr) => {
       expect(xhr.request.method).to.equal('GET')
       expect(xhr.response.body).to.have.property('type')
       expect(xhr.response.body.type).to.equal('FeatureCollection')
       expect(xhr.response.body.numberMatched).to.be.equal(14)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
+
     cy.contains('#num-records-oapif-download', /Total number of records: \d+/).should('be.visible')
 
     // visit download link (replace with limit 1)

--- a/tests/e2e/specs/raster-drill.js
+++ b/tests/e2e/specs/raster-drill.js
@@ -1,5 +1,8 @@
 // https://docs.cypress.io/api/introduction/api.html
 
+const TIMEOUT_MS = 6500;
+const INTERVAL_MS = 2000;
+
 describe('E2E test for raster drill data with various form options', () => {
   it('Visits CMIP5 and perform raster drill downloads, as GeoJSON format', () => {
     cy.visit('/#/cmip5-data')
@@ -25,7 +28,7 @@ describe('E2E test for raster drill data with various form options', () => {
     cy.get('#point-download-box').scrollIntoView().wait(250).should('have.class', 'alert-success')
     cy.intercept('POST', /.*\/processes\/raster-drill\/execution.*/).as('rasterDrillDownload')
     cy.get('#point-download-box button').click()
-    cy.wait('@rasterDrillDownload', { timeout: 120000 }).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@rasterDrillDownload').then((xhr) => {
       try {
         expect(xhr.response.headers).to.have.property('content-encoding')
         expect(xhr.response.headers['content-encoding']).to.match(/gzip/ig)
@@ -35,6 +38,12 @@ describe('E2E test for raster drill data with various form options', () => {
       expect(xhr.request.method).to.equal('POST')
       expect(xhr.response.statusCode).to.equal(200)
       expect(xhr.response.body.properties.values.length).to.be.greaterThan(90)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
   })
 
@@ -62,7 +71,7 @@ describe('E2E test for raster drill data with various form options', () => {
     cy.get('#point-download-box').scrollIntoView().wait(250).should('have.class', 'alert-success')
     cy.intercept('POST', /.*\/processes\/raster-drill\/execution.*/).as('rasterDrillDownload')
     cy.get('#point-download-box button').click()
-    cy.wait('@rasterDrillDownload', { timeout: 120000 }).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@rasterDrillDownload').then((xhr) => {
       try {
         expect(xhr.response.headers).to.have.property('content-encoding')
         expect(xhr.response.headers['content-encoding']).to.match(/gzip/ig)
@@ -72,6 +81,12 @@ describe('E2E test for raster drill data with various form options', () => {
       expect(xhr.request.method).to.equal('POST')
       expect(xhr.response.statusCode).to.equal(200)
       expect(xhr.response.body).to.contain('time_2006/2100/P1Y,values,longitude,latitude')
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
   })
 
@@ -99,7 +114,7 @@ describe('E2E test for raster drill data with various form options', () => {
     cy.get('#point-download-box').scrollIntoView().wait(250).should('have.class', 'alert-success')
     cy.intercept('POST', /.*\/processes\/raster-drill\/execution.*/).as('rasterDrillDownload')
     cy.get('#point-download-box button').click()
-    cy.wait('@rasterDrillDownload', { timeout: 120000 }).then((xhr) => {
+    cy.waitUntil(() => cy.wait('@rasterDrillDownload').then((xhr) => {
       try {
         expect(xhr.response.headers).to.have.property('content-encoding')
         expect(xhr.response.headers['content-encoding']).to.match(/gzip/ig)
@@ -109,6 +124,12 @@ describe('E2E test for raster drill data with various form options', () => {
       expect(xhr.request.method).to.equal('POST')
       expect(xhr.response.statusCode).to.equal(200)
       expect(xhr.response.body.properties.values.length).to.be.greaterThan(100)
+    }), {
+      errorMsg: 'Timeout reached', // overrides the default error message
+      timeout: TIMEOUT_MS, // waits up to TIMEOUT_MS, default to 6500 ms
+      interval: INTERVAL_MS, // performs the check every INTERVAL_MS, default to 2000 ms
+      verbose: true, // log the progress, default to false
+      customCheckMessage: 'WaitUntil Check Happened' // check message, happens for every single check
     })
   })
 })

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -25,6 +25,8 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 // VarSelect.vue or dropdown components
+import 'cypress-wait-until';
+
 Cypress.Commands.add('selectVar', (getInput, text, value) => {
   cy.get(getInput).scrollIntoView().wait(250).select(text).should('have.value', value)
   return cy.get(getInput)


### PR DESCRIPTION
As Noted: "From a cold start, ES can take time to warm up if no requests have been made recently. Usually after a timeout, and you rerun the XHR again, the results return very quickly.

The E2E tests only sets a long timeout, but ideally a retry attempt should be used."

Retires of ```xhr``` made possible via: https://github.com/NoriSte/cypress-wait-until

added `.waitUntil()` to all instances of `.wait()` regarding `xhr`, added `tsconfig.json` under `cypress` folder as required to properly import the library (changed `.gitignore` to include this). Added import in `commands.js`

Upon testing, all previous instances of `xhr` pass. Some tests still fail. However, this is not to do with the `timeout` on waiting for `xhr` (mostly assertion errors or cypress errors)

Files changed/tested (With regards to actually running Cypress): `"Climate-hourly.js", "climate-daily.js", "climate-monthly.js", "climate-normal.js", "ahccd.js", "home.js", "hydrometric.js", "raster-drill.js", "itce.js"`