### PR TITLE
update CCCS Data Extraction UI to use CanSIPS products issue-1029

### DIFF
--- a/locales/json/translations.json
+++ b/locales/json/translations.json
@@ -538,12 +538,30 @@
 				]
 			}
 		},
+		"startYYYYMM and endYYYYMM represent the start and end dates. periodValue represents the forecast period": {
+			"{startYYYYMM} to {endYYYYMM} ({periodValue})": {
+				"msgid": "{startYYYYMM} to {endYYYYMM} ({periodValue})",
+				"msgctxt": "startYYYYMM and endYYYYMM represent the start and end dates. periodValue represents the forecast period",
+				"msgstr": [
+					""
+				]
+			}
+		},
 		"Template for different file formats": {
 			"A region as a {format1} or {format2}": {
 				"msgid": "A region as a {format1} or {format2}",
 				"msgctxt": "Template for different file formats",
 				"msgstr": [
 					"A region as a {format1} or {format2}"
+				]
+			}
+		},
+		"The dropdown display for an exceedence product. option specifies the product, units depends on the variable type": {
+			"Probability greater than {exceedOption} {varUnits}": {
+				"msgid": "Probability greater than {exceedOption} {varUnits}",
+				"msgctxt": "The dropdown display for an exceedence product. option specifies the product, units depends on the variable type",
+				"msgstr": [
+					""
 				]
 			}
 		},
@@ -879,12 +897,6 @@
 				"msgid": "Air temperature",
 				"msgstr": [
 					"Air temperature"
-				]
-			},
-			"Air temperature at 850mb": {
-				"msgid": "Air temperature at 850mb",
-				"msgstr": [
-					"Air temperature at 850mb"
 				]
 			},
 			"Alberta": {
@@ -1457,6 +1469,18 @@
 					"Forecast month"
 				]
 			},
+			"Forecast months": {
+				"msgid": "Forecast months",
+				"msgstr": [
+					""
+				]
+			},
+			"Forecast period": {
+				"msgid": "Forecast period",
+				"msgstr": [
+					""
+				]
+			},
 			"Frequently asked questions about LTCE": {
 				"msgid": "Frequently asked questions about LTCE",
 				"msgstr": [
@@ -1467,12 +1491,6 @@
 				"msgid": "Future",
 				"msgstr": [
 					"Future"
-				]
-			},
-			"Geopotential height at 500mb": {
-				"msgid": "Geopotential height at 500mb",
-				"msgstr": [
-					"Geopotential height at 500mb"
 				]
 			},
 			"Get started": {
@@ -1565,10 +1583,10 @@
 					"Information"
 				]
 			},
-			"Instantaneous precipitation rate (m/s)": {
-				"msgid": "Instantaneous precipitation rate (m/s)",
+			"Interval type": {
+				"msgid": "Interval type",
 				"msgstr": [
-					"Instantaneous precipitation rate (m/s)"
+					""
 				]
 			},
 			"It's possible that your selected location is not within the dataset boundary.": {
@@ -1701,12 +1719,6 @@
 				"msgid": "Mean temperature",
 				"msgstr": [
 					"Mean temperature"
-				]
-			},
-			"Member": {
-				"msgid": "Member",
-				"msgstr": [
-					"Member"
 				]
 			},
 			"Minimum temperature": {
@@ -1895,6 +1907,12 @@
 					"Please select a point on the map."
 				]
 			},
+			"Precipitation": {
+				"msgid": "Precipitation",
+				"msgstr": [
+					""
+				]
+			},
 			"Precipitation - Daily extremes of record": {
 				"msgid": "Precipitation - Daily extremes of record",
 				"msgstr": [
@@ -1917,6 +1935,30 @@
 				"msgid": "Prince Edward Island",
 				"msgstr": [
 					"Prince Edward Island"
+				]
+			},
+			"Probability": {
+				"msgid": "Probability",
+				"msgstr": [
+					""
+				]
+			},
+			"Probability above normal": {
+				"msgid": "Probability above normal",
+				"msgstr": [
+					""
+				]
+			},
+			"Probability below normal": {
+				"msgid": "Probability below normal",
+				"msgstr": [
+					""
+				]
+			},
+			"Probability near normal": {
+				"msgid": "Probability near normal",
+				"msgstr": [
+					""
 				]
 			},
 			"Province": {
@@ -1979,16 +2021,16 @@
 					"Sea ice thickness"
 				]
 			},
-			"Sea level pressure": {
-				"msgid": "Sea level pressure",
-				"msgstr": [
-					"Sea level pressure"
-				]
-			},
 			"Seasonal values": {
 				"msgid": "Seasonal values",
 				"msgstr": [
 					"Seasonal values"
+				]
+			},
+			"Seasonally": {
+				"msgid": "Seasonally",
+				"msgstr": [
+					""
 				]
 			},
 			"see FAQ": {
@@ -2547,12 +2589,6 @@
 				"msgid": "Visit <a href=\"{link}\" target=\"_blank\">ClimateData.ca</a> to access individual model output",
 				"msgstr": [
 					"Visit <a href=\"{link}\" target=\"_blank\">ClimateData.ca</a> to access individual model output"
-				]
-			},
-			"Water temperature": {
-				"msgid": "Water temperature",
-				"msgstr": [
-					"Water temperature"
 				]
 			},
 			"We value your feedback and are updating this tool continuously to ensure that it meets your needs. If you have any questions, comments or suggestions, <a href=\"{supportDeskUrl}\">contact the Climate Services Support Desk</a>.": {
@@ -3144,12 +3180,30 @@
 				]
 			}
 		},
+		"startYYYYMM and endYYYYMM represent the start and end dates. periodValue represents the forecast period": {
+			"{startYYYYMM} to {endYYYYMM} ({periodValue})": {
+				"msgid": "{startYYYYMM} to {endYYYYMM} ({periodValue})",
+				"msgctxt": "startYYYYMM and endYYYYMM represent the start and end dates. periodValue represents the forecast period",
+				"msgstr": [
+					"{startYYYYMM} à {endYYYYMM} ({periodValue})"
+				]
+			}
+		},
 		"Template for different file formats": {
 			"A region as a {format1} or {format2}": {
 				"msgid": "A region as a {format1} or {format2}",
 				"msgctxt": "Template for different file formats",
 				"msgstr": [
 					"une région sous forme de {format1} ou {format2}"
+				]
+			}
+		},
+		"The dropdown display for an exceedence product. option specifies the product, units depends on the variable type": {
+			"Probability greater than {exceedOption} {varUnits}": {
+				"msgid": "Probability greater than {exceedOption} {varUnits}",
+				"msgctxt": "The dropdown display for an exceedence product. option specifies the product, units depends on the variable type",
+				"msgstr": [
+					"Probabilité d'être plus que {exceedOption} {varUnits}"
 				]
 			}
 		},
@@ -3485,12 +3539,6 @@
 				"msgid": "Air temperature",
 				"msgstr": [
 					"Température de l'air"
-				]
-			},
-			"Air temperature at 850mb": {
-				"msgid": "Air temperature at 850mb",
-				"msgstr": [
-					"Température de l'air à 850 mb"
 				]
 			},
 			"Alberta": {
@@ -4063,6 +4111,18 @@
 					"Mois de la prévision"
 				]
 			},
+			"Forecast months": {
+				"msgid": "Forecast months",
+				"msgstr": [
+					"Les mois de la prévision"
+				]
+			},
+			"Forecast period": {
+				"msgid": "Forecast period",
+				"msgstr": [
+					"Période de la prévision"
+				]
+			},
 			"Frequently asked questions about LTCE": {
 				"msgid": "Frequently asked questions about LTCE",
 				"msgstr": [
@@ -4073,12 +4133,6 @@
 				"msgid": "Future",
 				"msgstr": [
 					"Futur"
-				]
-			},
-			"Geopotential height at 500mb": {
-				"msgid": "Geopotential height at 500mb",
-				"msgstr": [
-					"Hauteur géopotentielle à 500 mb"
 				]
 			},
 			"Get started": {
@@ -4171,10 +4225,10 @@
 					"Information"
 				]
 			},
-			"Instantaneous precipitation rate (m/s)": {
-				"msgid": "Instantaneous precipitation rate (m/s)",
+			"Interval type": {
+				"msgid": "Interval type",
 				"msgstr": [
-					"Taux instantané de précipitations (m/s)"
+					"Type d'intervalle"
 				]
 			},
 			"It's possible that your selected location is not within the dataset boundary.": {
@@ -4307,12 +4361,6 @@
 				"msgid": "Mean temperature",
 				"msgstr": [
 					"Température moyenne"
-				]
-			},
-			"Member": {
-				"msgid": "Member",
-				"msgstr": [
-					"Membre"
 				]
 			},
 			"Minimum temperature": {
@@ -4501,6 +4549,12 @@
 					"Veuillez sélectionner un point sur la carte."
 				]
 			},
+			"Precipitation": {
+				"msgid": "Precipitation",
+				"msgstr": [
+					"Précipitation"
+				]
+			},
 			"Precipitation - Daily extremes of record": {
 				"msgid": "Precipitation - Daily extremes of record",
 				"msgstr": [
@@ -4523,6 +4577,30 @@
 				"msgid": "Prince Edward Island",
 				"msgstr": [
 					"Île-du-Prince-Édouard"
+				]
+			},
+			"Probability": {
+				"msgid": "Probability",
+				"msgstr": [
+					"Probabilité"
+				]
+			},
+			"Probability above normal": {
+				"msgid": "Probability above normal",
+				"msgstr": [
+					"Probabilité d'être au-dessus de la normale"
+				]
+			},
+			"Probability below normal": {
+				"msgid": "Probability below normal",
+				"msgstr": [
+					"Probabilité d'être sous la normale"
+				]
+			},
+			"Probability near normal": {
+				"msgid": "Probability near normal",
+				"msgstr": [
+					"Probabilité d'être près de la normale"
 				]
 			},
 			"Province": {
@@ -4585,16 +4663,16 @@
 					"Épaisseur de la glace de mer"
 				]
 			},
-			"Sea level pressure": {
-				"msgid": "Sea level pressure",
-				"msgstr": [
-					"Pression au niveau de la mer"
-				]
-			},
 			"Seasonal values": {
 				"msgid": "Seasonal values",
 				"msgstr": [
 					"Valeurs saisonnières"
+				]
+			},
+			"Seasonally": {
+				"msgid": "Seasonally",
+				"msgstr": [
+					"Saisonnièrement"
 				]
 			},
 			"see FAQ": {
@@ -5153,12 +5231,6 @@
 				"msgid": "Visit <a href=\"{link}\" target=\"_blank\">ClimateData.ca</a> to access individual model output",
 				"msgstr": [
 					"Consultez <a href=\"{link}\" target=\"_blank\">donneesclimatiques.ca</a> pour obtenir les résultats d’un modèle individuel"
-				]
-			},
-			"Water temperature": {
-				"msgid": "Water temperature",
-				"msgstr": [
-					"Température de l'eau"
 				]
 			},
 			"We value your feedback and are updating this tool continuously to ensure that it meets your needs. If you have any questions, comments or suggestions, <a href=\"{supportDeskUrl}\">contact the Climate Services Support Desk</a>.": {

--- a/locales/po/en.po
+++ b/locales/po/en.po
@@ -289,13 +289,9 @@ msgstr ""
 "years are missing data or more than 10% of the data within the time series "
 "is missing, a trend was not calculated."
 
-#: src/views/CanSIPSForm.vue:174
+#: src/views/CanSIPSForm.vue:227
 msgid "Air temperature"
 msgstr "Air temperature"
-
-#: src/views/CanSIPSForm.vue:177
-msgid "Air temperature at 850mb"
-msgstr "Air temperature at 850mb"
 
 #: src/components/ProvinceSelect.vue:37
 msgid "Alberta"
@@ -899,14 +895,21 @@ msgstr ""
 "href=\"{techDocLink}\" target=\"_blank\">the technical documentation on the "
 "Canadian statistically downscaled climate scenarios</a>."
 
-#: src/views/CanSIPSForm.vue:167
+#: src/views/CanSIPSForm.vue:222
 msgid "Forecast"
 msgstr "Forecast"
 
-#: src/views/CanSIPSForm.vue:271
-#: src/views/CanSIPSForm.vue:63
+#: src/views/CanSIPSForm.vue:364
 msgid "Forecast month"
 msgstr "Forecast month"
+
+#: src/views/CanSIPSForm.vue:366
+msgid "Forecast months"
+msgstr ""
+
+#: src/views/CanSIPSForm.vue:59
+msgid "Forecast period"
+msgstr ""
 
 #: src/views/LTCEForm.vue:331
 msgid "Frequently asked questions about LTCE"
@@ -915,10 +918,6 @@ msgstr "Frequently asked questions about LTCE"
 #: src/components/mixins/oapi-coverages-dcs-cmip5.js:262
 msgid "Future"
 msgstr "Future"
-
-#: src/views/CanSIPSForm.vue:176
-msgid "Geopotential height at 500mb"
-msgstr "Geopotential height at 500mb"
 
 #: src/views/HomeView.vue:12
 msgid "Get started"
@@ -1005,9 +1004,9 @@ msgstr ""
 msgid "Information"
 msgstr "Information"
 
-#: src/views/CanSIPSForm.vue:173
-msgid "Instantaneous precipitation rate (m/s)"
-msgstr "Instantaneous precipitation rate (m/s)"
+#: src/views/CanSIPSForm.vue:30
+msgid "Interval type"
+msgstr ""
 
 #: src/components/PointDownloadBox.vue:25
 #. WPS error message
@@ -1133,22 +1132,16 @@ msgstr "Mean precipitation"
 msgid "Mean temperature"
 msgstr "Mean temperature"
 
-#: src/views/CanSIPSForm.vue:269
-#: src/views/CanSIPSForm.vue:44
-msgid "Member"
-msgstr "Member"
-
 #: src/views/CanGRDForm.vue:276
 #: src/views/DCSForm.vue:247
 msgid "Minimum temperature"
 msgstr "Minimum temperature"
 
-#: src/views/CanSIPSForm.vue:270
-#: src/views/CanSIPSForm.vue:52
+#: src/views/CanSIPSForm.vue:362
+#: src/views/CanSIPSForm.vue:48
 msgid "Model run month"
 msgstr "Model run month"
 
-#: src/views/CanSIPSForm.vue:36
 #: src/views/RDPAForm.vue:33
 msgid "Model type"
 msgstr "Model type"
@@ -1163,6 +1156,7 @@ msgstr "Month"
 
 #: src/components/mixins/oapi-coverages-dcs-cmip5.js:250
 #: src/views/CanGRDForm.vue:290
+#: src/views/CanSIPSForm.vue:299
 msgid "Monthly"
 msgstr "Monthly"
 
@@ -1307,6 +1301,10 @@ msgstr ""
 msgid "Please select a point on the map."
 msgstr "Please select a point on the map."
 
+#: src/views/CanSIPSForm.vue:228
+msgid "Precipitation"
+msgstr ""
+
 #: src/views/LTCEForm.vue:261
 msgid "Precipitation - Daily extremes of record"
 msgstr "Precipitation - Daily extremes of record"
@@ -1322,6 +1320,22 @@ msgstr "Previous"
 #: src/components/ProvinceSelect.vue:46
 msgid "Prince Edward Island"
 msgstr "Prince Edward Island"
+
+#: src/views/CanSIPSForm.vue:42
+msgid "Probability"
+msgstr ""
+
+#: src/views/CanSIPSForm.vue:238
+msgid "Probability above normal"
+msgstr ""
+
+#: src/views/CanSIPSForm.vue:239
+msgid "Probability below normal"
+msgstr ""
+
+#: src/views/CanSIPSForm.vue:237
+msgid "Probability near normal"
+msgstr ""
 
 #: src/views/AHCCDForm.vue:207
 #: src/views/ClimateDailyForm.vue:226
@@ -1374,13 +1388,13 @@ msgstr "Sea ice concentration"
 msgid "Sea ice thickness"
 msgstr "Sea ice thickness"
 
-#: src/views/CanSIPSForm.vue:172
-msgid "Sea level pressure"
-msgstr "Sea level pressure"
-
 #: src/views/AHCCDForm.vue:217
 msgid "Seasonal values"
 msgstr "Seasonal values"
+
+#: src/views/CanSIPSForm.vue:300
+msgid "Seasonally"
+msgstr ""
 
 #: src/views/LTCEForm.vue:331
 msgid "see FAQ"
@@ -2055,7 +2069,7 @@ msgid "Value-added historical climate data products"
 msgstr "Value-added historical climate data products"
 
 #: src/views/CanGRDForm.vue:42
-#: src/views/CanSIPSForm.vue:30
+#: src/views/CanSIPSForm.vue:36
 msgid "Variable"
 msgstr "Variable"
 
@@ -2118,10 +2132,6 @@ msgid ""
 msgstr ""
 "Visit <a href=\"{link}\" target=\"_blank\">ClimateData.ca</a> to access "
 "individual model output"
-
-#: src/views/CanSIPSForm.vue:175
-msgid "Water temperature"
-msgstr "Water temperature"
 
 #: src/components/InfoContactSupport.vue:18
 msgid ""
@@ -2451,9 +2461,9 @@ msgstr "You are here:"
 #: src/views/AHCCDForm.vue:236
 #: src/views/AHCCDForm.vue:240
 #: src/views/AHCCDForm.vue:245
-#: src/views/CanSIPSForm.vue:269
-#: src/views/CanSIPSForm.vue:270
-#: src/views/CanSIPSForm.vue:271
+#: src/views/CanSIPSForm.vue:362
+#: src/views/CanSIPSForm.vue:364
+#: src/views/CanSIPSForm.vue:366
 #: src/views/ClimateDailyForm.vue:238
 #: src/views/ClimateDailyForm.vue:242
 #: src/views/ClimateDailyForm.vue:246
@@ -2564,10 +2574,25 @@ msgctxt "Select option for None in a dropdown menu"
 msgid "-- None --"
 msgstr "-- None --"
 
+#: src/views/CanSIPSForm.vue:276
+#: src/views/CanSIPSForm.vue:289
+msgctxt ""
+"startYYYYMM and endYYYYMM represent the start and end dates. periodValue "
+"represents the forecast period"
+msgid "{startYYYYMM} to {endYYYYMM} ({periodValue})"
+msgstr ""
+
 #: src/components/BBOXMap.vue:451
 msgctxt "Template for different file formats"
 msgid "A region as a {format1} or {format2}"
 msgstr "A region as a {format1} or {format2}"
+
+#: src/views/CanSIPSForm.vue:250
+msgctxt ""
+"The dropdown display for an exceedence product. option specifies the "
+"product, units depends on the variable type"
+msgid "Probability greater than {exceedOption} {varUnits}"
+msgstr ""
 
 #: src/components/BBOXMap.vue:458
 msgctxt "Title"

--- a/locales/po/fr.po
+++ b/locales/po/fr.po
@@ -10,7 +10,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 2.4.3\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: src/components/MoreResources.vue:32
@@ -292,13 +292,9 @@ msgstr ""
 "données d’une ou de plusieurs stations à l’aide de l’outil d’extraction de "
 "données climatiques."
 
-#: src/views/CanSIPSForm.vue:174
+#: src/views/CanSIPSForm.vue:227
 msgid "Air temperature"
 msgstr "Température de l'air"
-
-#: src/views/CanSIPSForm.vue:177
-msgid "Air temperature at 850mb"
-msgstr "Température de l'air à 850 mb"
 
 #: src/components/ProvinceSelect.vue:37
 msgid "Alberta"
@@ -923,14 +919,21 @@ msgstr ""
 "target=\"_blank\">documentation technique relative aux Scénarios "
 "climatiques canadiens mis à l’échelle de manière statistique</a>."
 
-#: src/views/CanSIPSForm.vue:167
+#: src/views/CanSIPSForm.vue:222
 msgid "Forecast"
 msgstr "Prévision"
 
-#: src/views/CanSIPSForm.vue:271
-#: src/views/CanSIPSForm.vue:63
+#: src/views/CanSIPSForm.vue:364
 msgid "Forecast month"
 msgstr "Mois de la prévision"
+
+#: src/views/CanSIPSForm.vue:366
+msgid "Forecast months"
+msgstr "Les mois de la prévision"
+
+#: src/views/CanSIPSForm.vue:59
+msgid "Forecast period"
+msgstr "Période de la prévision"
 
 #: src/views/LTCEForm.vue:331
 msgid "Frequently asked questions about LTCE"
@@ -939,10 +942,6 @@ msgstr "Foire aux questions à propos de l'ECLT"
 #: src/components/mixins/oapi-coverages-dcs-cmip5.js:262
 msgid "Future"
 msgstr "Futur"
-
-#: src/views/CanSIPSForm.vue:176
-msgid "Geopotential height at 500mb"
-msgstr "Hauteur géopotentielle à 500 mb"
 
 #: src/views/HomeView.vue:12
 msgid "Get started"
@@ -1034,9 +1033,9 @@ msgstr ""
 msgid "Information"
 msgstr "Information"
 
-#: src/views/CanSIPSForm.vue:173
-msgid "Instantaneous precipitation rate (m/s)"
-msgstr "Taux instantané de précipitations (m/s)"
+#: src/views/CanSIPSForm.vue:30
+msgid "Interval type"
+msgstr "Type d'intervalle"
 
 #: src/components/PointDownloadBox.vue:25
 #. WPS error message
@@ -1162,22 +1161,16 @@ msgstr "Moyenne des précipitations"
 msgid "Mean temperature"
 msgstr "Température moyenne"
 
-#: src/views/CanSIPSForm.vue:269
-#: src/views/CanSIPSForm.vue:44
-msgid "Member"
-msgstr "Membre"
-
 #: src/views/CanGRDForm.vue:276
 #: src/views/DCSForm.vue:247
 msgid "Minimum temperature"
 msgstr "Température minimale"
 
-#: src/views/CanSIPSForm.vue:270
-#: src/views/CanSIPSForm.vue:52
+#: src/views/CanSIPSForm.vue:362
+#: src/views/CanSIPSForm.vue:48
 msgid "Model run month"
 msgstr "Mois de la simulation du modèle"
 
-#: src/views/CanSIPSForm.vue:36
 #: src/views/RDPAForm.vue:33
 msgid "Model type"
 msgstr "Type de modèle"
@@ -1192,6 +1185,7 @@ msgstr "Mois"
 
 #: src/components/mixins/oapi-coverages-dcs-cmip5.js:250
 #: src/views/CanGRDForm.vue:290
+#: src/views/CanSIPSForm.vue:299
 msgid "Monthly"
 msgstr "Mensuel"
 
@@ -1344,6 +1338,10 @@ msgstr ""
 msgid "Please select a point on the map."
 msgstr "Veuillez sélectionner un point sur la carte."
 
+#: src/views/CanSIPSForm.vue:228
+msgid "Precipitation"
+msgstr "Précipitation"
+
 #: src/views/LTCEForm.vue:261
 msgid "Precipitation - Daily extremes of record"
 msgstr "Précipitations - Extrêmes quotidiens"
@@ -1359,6 +1357,22 @@ msgstr "Précédent"
 #: src/components/ProvinceSelect.vue:46
 msgid "Prince Edward Island"
 msgstr "Île-du-Prince-Édouard"
+
+#: src/views/CanSIPSForm.vue:42
+msgid "Probability"
+msgstr "Probabilité"
+
+#: src/views/CanSIPSForm.vue:238
+msgid "Probability above normal"
+msgstr "Probabilité d'être au-dessus de la normale"
+
+#: src/views/CanSIPSForm.vue:239
+msgid "Probability below normal"
+msgstr "Probabilité d'être sous la normale"
+
+#: src/views/CanSIPSForm.vue:237
+msgid "Probability near normal"
+msgstr "Probabilité d'être près de la normale"
 
 #: src/views/AHCCDForm.vue:207
 #: src/views/ClimateDailyForm.vue:226
@@ -1411,13 +1425,13 @@ msgstr "Concentration des glaces de mer"
 msgid "Sea ice thickness"
 msgstr "Épaisseur de la glace de mer"
 
-#: src/views/CanSIPSForm.vue:172
-msgid "Sea level pressure"
-msgstr "Pression au niveau de la mer"
-
 #: src/views/AHCCDForm.vue:217
 msgid "Seasonal values"
 msgstr "Valeurs saisonnières"
+
+#: src/views/CanSIPSForm.vue:300
+msgid "Seasonally"
+msgstr "Saisonnièrement"
 
 #: src/views/LTCEForm.vue:331
 msgid "see FAQ"
@@ -2132,7 +2146,7 @@ msgid "Value-added historical climate data products"
 msgstr "Produits à valeur ajoutée dérivés de données climatiques historiques"
 
 #: src/views/CanGRDForm.vue:42
-#: src/views/CanSIPSForm.vue:30
+#: src/views/CanSIPSForm.vue:36
 msgid "Variable"
 msgstr "Variables"
 
@@ -2196,10 +2210,6 @@ msgid ""
 msgstr ""
 "Consultez <a href=\"{link}\" target=\"_blank\">donneesclimatiques.ca</a> "
 "pour obtenir les résultats d’un modèle individuel"
-
-#: src/views/CanSIPSForm.vue:175
-msgid "Water temperature"
-msgstr "Température de l'eau"
 
 #: src/components/InfoContactSupport.vue:18
 msgid ""
@@ -2530,9 +2540,9 @@ msgstr "Vous êtes ici :"
 #: src/views/AHCCDForm.vue:236
 #: src/views/AHCCDForm.vue:240
 #: src/views/AHCCDForm.vue:245
-#: src/views/CanSIPSForm.vue:269
-#: src/views/CanSIPSForm.vue:270
-#: src/views/CanSIPSForm.vue:271
+#: src/views/CanSIPSForm.vue:362
+#: src/views/CanSIPSForm.vue:364
+#: src/views/CanSIPSForm.vue:366
 #: src/views/ClimateDailyForm.vue:238
 #: src/views/ClimateDailyForm.vue:242
 #: src/views/ClimateDailyForm.vue:246
@@ -2643,10 +2653,25 @@ msgctxt "Select option for None in a dropdown menu"
 msgid "-- None --"
 msgstr "-- Aucun --"
 
+#: src/views/CanSIPSForm.vue:276
+#: src/views/CanSIPSForm.vue:289
+msgctxt ""
+"startYYYYMM and endYYYYMM represent the start and end dates. periodValue "
+"represents the forecast period"
+msgid "{startYYYYMM} to {endYYYYMM} ({periodValue})"
+msgstr "{startYYYYMM} à {endYYYYMM} ({periodValue})"
+
 #: src/components/BBOXMap.vue:451
 msgctxt "Template for different file formats"
 msgid "A region as a {format1} or {format2}"
 msgstr "une région sous forme de {format1} ou {format2}"
+
+#: src/views/CanSIPSForm.vue:250
+msgctxt ""
+"The dropdown display for an exceedence product. option specifies the "
+"product, units depends on the variable type"
+msgid "Probability greater than {exceedOption} {varUnits}"
+msgstr "Probabilité d'être plus que {exceedOption} {varUnits}"
 
 #: src/components/BBOXMap.vue:458
 msgctxt "Title"

--- a/tests/e2e/specs/cansips.js
+++ b/tests/e2e/specs/cansips.js
@@ -1,211 +1,329 @@
 // https://docs.cypress.io/api/introduction/api.html
 
 describe('E2E test for CanSIPS ogc-api-coverage data with various form options', () => {
-  it('Test form changes and download sea level pressure data as CoverageJSON', () => {
-    cy.visit('/#/seasonal-forecasts')
+    it('Test startup values', () => {
+        cy.visit('/#/seasonal-forecasts')
 
-    let varName = 'Sea level pressure'
-    let varVal = '4'
-    let member = '8'
-    let modelDate = '2018-03'
-    let forecastDate = '2018-04'
-    let formatName = 'CoverageJSON'
-    let formatVal = 'json'
+        cy.get('#var-sel-interval-type').should('have.value', 'monthly-products')
+        cy.get('#var-sel-variable').should('have.value', 'AirTemp')
+        cy.get('#var-sel-probability').should('have.value', '-ProbNearNormal')
 
-    // model type is disabled
-    cy.get('#var-sel-model-type').scrollIntoView().should('be.disabled')
+        // Get the current month and year
+        const currDate = new Date().toJSON().slice(0, 7);
 
-    // variable
-    cy.selectVar('#var-sel-variable', varName, varVal)
-
-    // member
-    cy.inputText('#nummember', member)
-
-    // date
-    cy.inputText('#date-model-run-month', `${modelDate}{enter}`)
-    cy.get('#date-forecast-month').should('have.value', forecastDate)
-
-    // download format
-    cy.selectVar('#file_download_format', formatName, formatVal)
-
-    // visit download link
-    cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
-    cy.get('a#download-url').should('have.attr', 'href').then((href) => {
-      cy.request('GET', href).then((response) => {
-        expect(response.status).to.equal(200)
-        expect(response.body.type).to.equal('Coverage')
-        expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
-      })
+        cy.get('#date-model-run-month').should('have.value', currDate)
+        cy.get('#var-sel-forecast-period').should('have.value', 'P00M')
+        cy.get('#file_download_format').should('have.value', 'json')
     })
-  })
+    it('Test download monthly air temp data', () => {
+        cy.selectVar('#var-sel-interval-type', 'Monthly', 'monthly-products')
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
+        cy.selectVar('#var-sel-probability', 'Probability near normal', '-ProbNearNormal')
+        cy.inputText('#date-model-run-month', '2025-03{enter}')
+        cy.selectVar('#var-sel-forecast-period', '2025-03 (P00M)', 'P00M')
 
-  it('Download air temperature data as CoverageJSON', () => {
-    // Reset map
-    cy.get('#reset-map-view').scrollIntoView().wait(250).click()
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
 
-    // Zoom in to map
-    cy.get('a.leaflet-control-zoom-in').scrollIntoView().wait(250).click()
-    cy.wait(500) // mimic user pause after a zoom click
-
-    let varName = 'Air temperature'
-    let varVal = '1'
-    let member = '2'
-    let modelDate = '2018-06'
-    let forecastDate = '2018-07'
-    let formatName = 'CoverageJSON'
-    let formatVal = 'json'
-
-    // model type is disabled
-    cy.get('#var-sel-model-type').scrollIntoView().should('be.disabled')
-
-    // variable
-    cy.selectVar('#var-sel-variable', varName, varVal)
-
-    // member
-    cy.inputText('#nummember', member)
-
-    // date
-    cy.inputText('#date-model-run-month', `${modelDate}{enter}`)
-    cy.get('#date-forecast-month').should('have.value', forecastDate)
-
-    // download format
-    cy.selectVar('#file_download_format', formatName, formatVal)
-
-    // visit download link
-    cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
-    cy.get('a#download-url').should('have.attr', 'href').then((href) => {
-      cy.request('GET', href).then((response) => {
-        expect(response.status).to.equal(200)
-        expect(response.body.type).to.equal('Coverage')
-        expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
-      })
+        // Change the period
+        cy.selectVar('#var-sel-forecast-period', '2026-02 (P11M)', 'P11M')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
     })
-  })
-
-  it('Download water temperature data as CoverageJSON', () => {
-    // Reset map
-    cy.get('#reset-map-view').scrollIntoView().wait(250).click()
-
-    // Zoom in to map
-    cy.get('a.leaflet-control-zoom-in').scrollIntoView().wait(250).click()
-    cy.wait(500) // mimic user pause after a zoom click
-    cy.get('a.leaflet-control-zoom-in').click() // zoom twice
-    cy.wait(500)
-
-    let varName = 'Water temperature'
-    let varVal = '6'
-    let member = '5'
-    let modelDate = '2017-11'
-    let forecastDate = '2017-12'
-    let formatName = 'CoverageJSON'
-    let formatVal = 'json'
-
-    // model type is disabled
-    cy.get('#var-sel-model-type').scrollIntoView().should('be.disabled')
-
-    // variable
-    cy.selectVar('#var-sel-variable', varName, varVal)
-
-    // member
-    cy.inputText('#nummember', member)
-
-    // date
-    cy.inputText('#date-model-run-month', `${modelDate}{enter}`)
-    cy.get('#date-forecast-month').should('have.value', forecastDate)
-
-    // download format
-    cy.selectVar('#file_download_format', formatName, formatVal)
-
-    // visit download link
-    cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
-    cy.get('a#download-url').should('have.attr', 'href').then((href) => {
-      cy.request('GET', href).then((response) => {
-        expect(response.status).to.equal(200)
-        expect(response.body.type).to.equal('Coverage')
-        expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
-      })
+    it('Test download seasonal air temp data', () => {
+        cy.selectVar('#var-sel-interval-type', 'Seasonally', 'seasonal-products')
+        cy.inputText('#date-model-run-month', `2023-10{enter}`)
+        //cy.selectVar('#var-sel-forecast-period', '2023-10 to 2023-12 (P00M-P02M)', 'P00M-P02M')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
     })
-  })
+    it('Test unit change according to Variable type', () => {
+        // First ensure that the monthly data is selected
+        cy.selectVar('#var-sel-interval-type', 'Monthly', 'monthly-products')
+        cy.inputText('#date-model-run-month', `2025-03{enter}`)
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
+        cy.selectVar('#var-sel-probability', 'Probability greater than 40 K', '-ProbGT40Pct')
 
-  it('Download air temperature at 850mb data as GRIB', () => {
-    // Reset map
-    cy.get('#reset-map-view').scrollIntoView().wait(250).click()
+        // Now we change the variable type
+        cy.selectVar('#var-sel-variable', 'Precipitation', 'PrecipAccum')
+        // Now the probability should be using the precipiation units
+        
+        // Form text is retrieved all as one text
+        const expectedPrecip = 'Probability near normal' +
+                                'Probability above normal' +
+                                'Probability below normal' +
+                                'Probability greater than 10 kg/(m²)' +
+                                'Probability greater than 20 kg/(m²)' +
+                                'Probability greater than 30 kg/(m²)' +
+                                'Probability greater than 40 kg/(m²)' +
+                                'Probability greater than 50 kg/(m²)' +
+                                'Probability greater than 60 kg/(m²)' +
+                                'Probability greater than 70 kg/(m²)' +
+                                'Probability greater than 80 kg/(m²)' +
+                                'Probability greater than 90 kg/(m²)'
+        cy.get('#var-sel-probability').should('have.text', expectedPrecip)
 
-    let varName = 'Air temperature at 850mb'
-    let varVal = '5'
-    let member = '13'
-    let modelDate = '2013-05'
-    let forecastDate = '2013-06'
-    let formatName = 'GRIB'
-    let formatVal = 'GRIB'
+        // Now we change it back to air temperature to check if the units change as expected
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
 
-    // model type is disabled
-    cy.get('#var-sel-model-type').scrollIntoView().should('be.disabled')
-
-    // variable
-    cy.selectVar('#var-sel-variable', varName, varVal)
-
-    // member
-    cy.inputText('#nummember', member)
-
-    // date
-    cy.inputText('#date-model-run-month', `${modelDate}{enter}`)
-    cy.get('#date-forecast-month').should('have.value', forecastDate)
-
-    // download format
-    cy.selectVar('#file_download_format', formatName, formatVal)
-
-    // visit download link
-    cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
-    cy.get('a#download-url').should('have.attr', 'href').then((href) => {
-      cy.request('GET', href).then((response) => {
-        expect(response.status).to.equal(200)
-        expect(response.headers['content-disposition']).to.match(/.*cansips_forecast_raw_latlon2\.5x2\.5_TMP_ISBL_0850_2013-05_allmembers\.grib2.*$/)
-      })
+        const expectedTemps = 'Probability near normal' +
+                                'Probability above normal' +
+                                'Probability below normal' +
+                                'Probability greater than 10 K' +
+                                'Probability greater than 20 K' +
+                                'Probability greater than 30 K' +
+                                'Probability greater than 40 K' +
+                                'Probability greater than 50 K' +
+                                'Probability greater than 60 K' +
+                                'Probability greater than 70 K' +
+                                'Probability greater than 80 K' +
+                                'Probability greater than 90 K'
+        cy.get('#var-sel-probability').should('have.text', expectedTemps)
     })
-  })
+    it("Test changing forecast periods for different interval types", () => {
+        // Set values for monthly interval
+        cy.selectVar('#var-sel-interval-type', 'Monthly', 'monthly-products')
+        cy.inputText('#date-model-run-month', `2025-05{enter}`)
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
+        cy.selectVar('#var-sel-probability', 'Probability near normal', '-ProbNearNormal')
+        cy.selectVar('#var-sel-forecast-period', '2025-06 (P01M)', 'P01M')
 
-  it('Download Instantaneous precipitation rate (m/s) data as GRIB', () => {
-    // Reset map
-    cy.get('#reset-map-view').scrollIntoView().wait(250).click()
+        // Next, it is changed to the seasonal interval, and the forecast period should change as desired
 
-    // Zoom in to map
-    cy.get('a.leaflet-control-zoom-in').scrollIntoView().wait(250).click()
-    cy.wait(500) // mimic user pause after a zoom click
-    cy.get('a.leaflet-control-zoom-in').click() // zoom twice
-    cy.wait(500)
+        // Periods for all seasonal gpt products
+        var expectedPeriods = '2025-05 to 2025-07 (P00M-P02M)' +
+                              '2025-06 to 2025-08 (P01M-P03M)' +
+                              '2025-07 to 2025-09 (P02M-P04M)' +
+                              '2025-08 to 2025-10 (P03M-P05M)' +
+                              '2025-09 to 2025-11 (P04M-P06M)' +
+                              '2025-10 to 2025-12 (P05M-P07M)' +
+                              '2025-11 to 2026-01 (P06M-P08M)' +
+                              '2025-12 to 2026-02 (P07M-P09M)' +
+                              '2026-01 to 2026-03 (P08M-P10M)' +
+                              '2026-02 to 2026-04 (P09M-P11M)'
 
-    let varName = 'Instantaneous precipitation rate (m/s)'
-    let varVal = '3'
-    let member = '10'
-    let modelDate = '2016-08'
-    let forecastDate = '2016-09'
-    let formatName = 'GRIB'
-    let formatVal = 'GRIB'
+        // Periods for seasonal probability products
+        const expectedPeriodsSeasonalProb = '2025-05 to 2025-07 (P00M-P02M)' +
+                                            '2025-06 to 2025-08 (P01M-P03M)' +
+                                            '2025-08 to 2025-10 (P03M-P05M)' +
+                                            '2025-11 to 2026-01 (P06M-P08M)' +
+                                            '2026-02 to 2026-04 (P09M-P11M)'
 
-    // model type is disabled
-    cy.get('#var-sel-model-type').scrollIntoView().should('be.disabled')
+        cy.selectVar('#var-sel-interval-type', 'Seasonally', 'seasonal-products')
+        cy.get('#var-sel-forecast-period').should('have.value', 'P00M-P02M').should('have.text', expectedPeriodsSeasonalProb)
 
-    // variable
-    cy.selectVar('#var-sel-variable', varName, varVal)
+        // Then we change it back to monthly to ensure that the dates are displayed properly
+        cy.selectVar('#var-sel-interval-type', 'Monthly', 'monthly-products')
 
-    // member
-    cy.inputText('#nummember', member)
+        const expectedPeriodsMonth = '2025-05 (P00M)' +
+                                     '2025-06 (P01M)' +
+                                     '2025-07 (P02M)' +
+                                     '2025-08 (P03M)' +
+                                     '2025-09 (P04M)' +
+                                     '2025-10 (P05M)' +
+                                     '2025-11 (P06M)' +
+                                     '2025-12 (P07M)' +
+                                     '2026-01 (P08M)' +
+                                     '2026-02 (P09M)' +
+                                     '2026-03 (P10M)' +
+                                     '2026-04 (P11M)'
+        cy.get('#var-sel-forecast-period').should('have.value', 'P00M').should('have.text', expectedPeriodsMonth)
 
-    // date
-    cy.inputText('#date-model-run-month', `${modelDate}{enter}`)
-    cy.get('#date-forecast-month').should('have.value', forecastDate)
+        // Also check that other seasonal is ok
+        cy.selectVar('#var-sel-interval-type', 'Seasonally', 'seasonal-products')
+        cy.selectVar('#var-sel-probability', 'Probability greater than 40 K', '-ProbGT40Pct')
+        cy.get('#var-sel-forecast-period').should('have.value', 'P00M-P02M').should('have.text', expectedPeriods)
 
-    // download format
-    cy.selectVar('#file_download_format', formatName, formatVal)
-
-    // visit download link
-    cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
-    cy.get('a#download-url').should('have.attr', 'href').then((href) => {
-      cy.request('GET', href).then((response) => {
-        expect(response.status).to.equal(200)
-        expect(response.headers['content-disposition']).to.match(/.*cansips_forecast_raw_latlon2\.5x2\.5_PRATE_SFC_0_2016-08_allmembers\.grib2.*$/)
-      })
     })
-  })
+    it("Testing that options for monthly data can be shown as JSON", () => {
+        // First set the data download to monthly airtemp
+        cy.selectVar('#var-sel-interval-type', 'Monthly', 'monthly-products')
+        cy.inputText('#date-model-run-month', `2025-03{enter}`)
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
+        cy.selectVar('#var-sel-probability', 'Probability below normal', '-ProbBelowNormal')
+
+        // Test that it works with this configuration
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+
+        // Now change the probability and see that it can be downloaded
+        cy.selectVar('#var-sel-probability', 'Probability greater than 70 K', '-ProbGT70Pct')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+
+        // Next change to Precipitation data
+        cy.selectVar('#var-sel-variable', 'Precipitation', 'PrecipAccum')
+        cy.selectVar('#var-sel-probability', 'Probability greater than 70 kg/(m²)', '-ProbGT70Pct')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+
+        // Lastly, test a different probability for Precipitation
+        cy.selectVar('#var-sel-probability', 'Probability below normal', '-ProbBelowNormal')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+    })
+    it("Testing that options for seasonal data can be shown as JSON", () => {
+        // First set the data download to seasonal airtemp
+        cy.selectVar('#var-sel-interval-type', 'Seasonally', 'seasonal-products')
+        cy.inputText('#date-model-run-month', `2025-03{enter}`)
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
+        cy.selectVar('#var-sel-probability', 'Probability below normal', '-ProbBelowNormal')
+
+        // Test that it works with this configuration
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+
+        // Now change the probability and see that it can be downloaded
+        cy.selectVar('#var-sel-probability', 'Probability greater than 70 K', '-ProbGT70Pct')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+
+        // Next change to Precipitation data
+        cy.selectVar('#var-sel-variable', 'Precipitation', 'PrecipAccum')
+        cy.selectVar('#var-sel-probability', 'Probability greater than 70 kg/(m²)', '-ProbGT70Pct')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+
+        // Lastly, test a different probability for Precipitation
+        cy.selectVar('#var-sel-probability', 'Probability below normal', '-ProbBelowNormal')
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.body.type).to.equal('Coverage')
+                expect(response.headers['content-type']).to.equal('application/prs.coverage+json')
+            })
+        })
+    })
+    it("Test download in GRIB format", () => {
+        // For this test, specify the properties:
+        cy.selectVar('#var-sel-interval-type', 'Monthly', 'monthly-products')
+        cy.inputText('#date-model-run-month', `2025-03{enter}`)
+        cy.selectVar('#var-sel-variable', 'Air temperature', 'AirTemp')
+        cy.selectVar('#var-sel-probability', 'Probability above normal', '-ProbAboveNormal')
+        cy.selectVar('#var-sel-forecast-period', '2025-03 (P00M)', 'P00M')
+        cy.selectVar('#file_download_format', 'GRIB', 'GRIB')
+        // visit download link
+        cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+        cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+            cy.request('GET', href).then((response) => {
+                expect(response.status).to.equal(200)
+                expect(response.headers['content-type']).to.equal('application/x-grib2')
+            })
+        })
+    })
+
+    /**
+     * The following are a series of tests created to check if data exists for all months and
+     * periods of specified configurations.
+     * 
+     * This no longer works due to the current implementation preventing users from selecting
+     * a period and date combination where data is not recorded.
+     * 
+     * It can be reworked for extensive testing if it is needed to find specific combinations
+     * where data is missing.
+     * 
+     * It is commented out below.
+     */
+    
+    /**
+    // When these tests were created seasonal probability products had a lower date bound of 2023-10
+    var firstDate = new Date('2023-10 12:00:00')
+    const periods = ['P00M-P02M', "P01M-P03M", 
+                "P02M-P04M", 'P03M-P05M', "P04M-P06M", 
+                "P05M-P07M", 'P06M-P08M', "P07M-P09M", 
+                "P08M-P10M", 'P09M-P11M']
+    const valuesForTesting = []
+    // Between (and including) 2023-10 to 2025-06 there are 21 months
+    for(var i=0; i<21; i++){
+        periods.forEach(period => {
+            var needToChange = (period === 'P00M-P02M')
+            valuesForTesting.push([i, period, needToChange])
+        })
+    }
+
+    // Tests are dynamically created. One for each entry in valuesForTesting
+    valuesForTesting.forEach(val => {
+        var checkMonth = firstDate.getMonth() +1 + val[0]
+        var checkYear = firstDate.getFullYear()
+
+        while(checkMonth > 12){
+            checkMonth = checkMonth - 12
+            checkYear = checkYear + 1
+        }
+        var formattedMonth = `${checkYear}-${checkMonth}`
+        it("Test current combination of CANSIPS product options", () => {
+            if(val[2] === true){
+                cy.inputText('#date-model-run-month', formattedMonth + '{enter}').wait(1050)
+            }
+            cy.get('#var-sel-forecast-period').select(val[1])
+
+            // Now select the download link and check if it works
+            cy.get('#url-download-box').scrollIntoView().wait(250).should('be.visible')
+            cy.get('a#download-url').should('have.attr', 'href').then((href) => {
+                cy.request({method: 'GET', url: href, failOnStatusCode: false}).should((response) => {
+                    expect(response.status).to.equal(200)
+                })
+            })
+        })
+    })*/
 })


### PR DESCRIPTION
This PR replaces the data retrieved when using the CanSIPS tool from member data to product data. The options are updated to reflect this change, and to account for the different time interval availabilities of different products, the tool dynamically adjusts the selectable dates as needed. 

Additionally, some French translations have been added for the product options in the tool.